### PR TITLE
Correct cents to pence for GBP

### DIFF
--- a/Duckling/AmountOfMoney/EN/Corpus.hs
+++ b/Duckling/AmountOfMoney/EN/Corpus.hs
@@ -76,7 +76,7 @@ allExamples = concat
              , "$20 43"
              , "20 dollar 43c"
              , "20 dollars 43 cents"
-  j          , "twenty dollar 43 cents"
+             , "twenty dollar 43 cents"
              , "20 dollar 43"
              , "twenty dollar and 43"
              ]

--- a/Duckling/AmountOfMoney/EN/Corpus.hs
+++ b/Duckling/AmountOfMoney/EN/Corpus.hs
@@ -76,14 +76,14 @@ allExamples = concat
              , "$20 43"
              , "20 dollar 43c"
              , "20 dollars 43 cents"
-             , "twenty dollar 43 cents"
+  j          , "twenty dollar 43 cents"
              , "20 dollar 43"
              , "twenty dollar and 43"
              ]
   , examples (AmountOfMoneyValue GBP 3.01)
              [ "GBP3.01"
              , "GBP 3.01"
-             , "3 GBP 1 cent"
+             , "3 GBP 1 pence"
              ]
   , examples (AmountOfMoneyValue Unnamed 42)
              [ "42 bucks"


### PR DESCRIPTION
GBP are broken up into 100 pence (or p) but not cents.