### PR TITLE
replace regex-pcre with regex-pcre-builtin

### DIFF
--- a/duckling.cabal
+++ b/duckling.cabal
@@ -486,7 +486,7 @@ library
                      , extra                 >= 1.4.10 && < 1.6
                      , hashable              >= 1.2.4.0 && < 1.3
                      , regex-base            >= 0.93.2 && < 0.94
-                     , regex-pcre            >= 0.94.4 && < 0.95
+                     , regex-pcre-builtin    >= 0.94.4 && < 0.95
                      , text                  >= 1.2.2.1 && < 1.3
                      , text-show             >= 2.1.2 && < 3.5
                      , time                  >= 1.5.0.1 && < 1.7
@@ -511,7 +511,7 @@ test-suite duckling-test
                      , dependent-sum         >= 0.3.2.2 && < 0.5
                      , hashable              >= 1.2.4.0 && < 1.3
                      , regex-base            >= 0.93.2 && < 0.94
-                     , regex-pcre            >= 0.94.4 && < 0.95
+                     , regex-pcre-builtin    >= 0.94.4 && < 0.95
                      , text                  >= 1.2.2.1 && < 1.3
                      , text-show             >= 2.1.2 && < 3.5
                      , time                  >= 1.5.0.1 && < 1.7
@@ -717,7 +717,7 @@ executable duckling-regen-exe
                      , hashable              >= 1.2.4.0 && < 1.3
                      , haskell-src-exts      >= 1.18 && < 1.19
                      , regex-base            >= 0.93.2 && < 0.94
-                     , regex-pcre            >= 0.94.4 && < 0.95
+                     , regex-pcre-builtin    >= 0.94.4 && < 0.95
                      , text                  >= 1.2.2.1 && < 1.3
                      , text-show             >= 2.1.2 && < 3.5
                      , time                  >= 1.5.0.1 && < 1.7


### PR DESCRIPTION
When stack build in macOS Sierra, it throws an error:

Configuring regex-pcre-0.94.4...
    Building regex-pcre-0.94.4...
    Preprocessing library regex-pcre-0.94.4...
    /private/var/folders/_0/94krv5257wb80bxj14lptj2m0000gn/T/stack38563/regex-pcre-0.94.4/Wrap.hsc:148:10: fatal error: 'pcre.h' file not found
    #include <pcre.h>
             ^
    1 error generated.

After I replace regex-pcre with regex-pcre-builtin in duckling.cabal, it works.

Please check it.