### PR TITLE
Update macOS PCRE instructions to include source headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Haskell environment is required. We recommend using
 On macOS you'll need to install PCRE development headers.
 The easiest way to do that is with [Homebrew](https://brew.sh/):
 ```
-brew install pcre
+HOMEBREW_BUILD_FROM_SOURCE=1 brew install pcre
 ```
 
 ## Quickstart


### PR DESCRIPTION
Apparently the default `pcre` homebrew package doesn't include source files. This updated command ensures development headers get pulled down when installing.

(Addresses issues discussed in #8)