### PR TITLE
Expanded english matching rules for miles and inches

### DIFF
--- a/Duckling/Distance/EN/Corpus.hs
+++ b/Duckling/Distance/EN/Corpus.hs
@@ -32,6 +32,7 @@ allExamples = concat
   , examples (DistanceValue Mile 8)
              [ "8 miles"
              , "eight mile"
+             , "8 mi"
              ]
   , examples (DistanceValue M 9)
              [ "9m"
@@ -39,5 +40,11 @@ allExamples = concat
   , examples (DistanceValue Centimetre 2)
              [ "2cm"
              , "2 centimeters"
+             ]
+  , examples (DistanceValue Inch 5)
+             [ "5 in"
+             , "5''"
+             , "five inches"
+             , "5\""
              ]
   ]

--- a/Duckling/Distance/EN/Rules.hs
+++ b/Duckling/Distance/EN/Rules.hs
@@ -58,11 +58,11 @@ ruleDistanceFeetAndInch = Rule
 distances :: [(Text, String, TDistance.Unit)]
 distances = [ ("<latent dist> km", "k(ilo)?m?(eter)?s?", TDistance.Kilometre)
             , ("<latent dist> feet", "('|f(oo|ee)?ts?)", TDistance.Foot)
-            , ("<latent dist> inch", "(''|inch(es)?)", TDistance.Inch)
+            , ("<latent dist> inch", "(\"|''|in(ch(es)?)?)", TDistance.Inch)
             , ("<latent dist> yard", "y(ar)?ds?", TDistance.Yard)
             , ("<dist> meters", "meters?", TDistance.Metre)
             , ("<dist> centimeters", "cm|centimeters?", TDistance.Centimetre)
-            , ("<dist> miles", "miles?", TDistance.Mile)
+            , ("<dist> miles", "mi(le(s)?)?", TDistance.Mile)
             , ("<dist> m (ambiguous miles or meters)", "m", TDistance.M)
             ]
 


### PR DESCRIPTION
Adds canonical abbreviation matching rules for miles ("mi",) and inches (" and "in".)