### PR TITLE
Updated Swedish time

### DIFF
--- a/Duckling/Time/SV/Rules.hs
+++ b/Duckling/Time/SV/Rules.hs
@@ -1024,7 +1024,7 @@ ruleAboutTimeofday :: Rule
 ruleAboutTimeofday = Rule
   { name = "about <time-of-day>"
   , pattern =
-    [ regex "(omkring|cirka|runt|ca\\.)( kl\\.| klockan)?"
+    [ regex "(omkring|cirka|vid|runt|ca\\.)( kl\\.| klockan)?"
     , Predicate isATimeOfDay
     ]
   , prod = \tokens -> case tokens of


### PR DESCRIPTION
Added `vid` to allow for sentences like `vid kl. 12` (-> `by 12 O'clock`)