### PR TITLE
Generalize mm/dd rules to accept spaces like '05 / 27', '05/ 27'

### DIFF
--- a/Duckling/Time/EN/Rules.hs
+++ b/Duckling/Time/EN/Rules.hs
@@ -699,7 +699,7 @@ ruleYYYYMMDD = Rule
 ruleMMDD :: Rule
 ruleMMDD = Rule
   { name = "mm/dd"
-  , pattern = [regex "(0?[1-9]|1[0-2])/(3[01]|[12]\\d|0?[1-9])"]
+  , pattern = [regex "(0?[1-9]|1[0-2])\\s?/\\s?(3[01]|[12]\\d|0?[1-9])"]
   , prod = \tokens -> case tokens of
       (Token RegexMatch (GroupMatch (mm:dd:_)):_) -> do
         m <- parseInt mm


### PR DESCRIPTION
The existing "mm/dd" rules only accepts format like "05/27"; However, in practice there might be extra spaces like "05 / 27", "05/ 27". The pull requests tweaks the regex to accept extra space.