### PR TITLE
Support dates of type mm-dd

### DIFF
--- a/Duckling/Time/EN/Rules.hs
+++ b/Duckling/Time/EN/Rules.hs
@@ -699,7 +699,7 @@ ruleYYYYMMDD = Rule
 ruleMMDD :: Rule
 ruleMMDD = Rule
   { name = "mm/dd"
-  , pattern = [regex "(0?[1-9]|1[0-2])\\s?/\\s?(3[01]|[12]\\d|0?[1-9])"]
+  , pattern = [regex "(0?[1-9]|1[0-2])\\s?[/-]\\s?(3[01]|[12]\\d|0?[1-9])"]
   , prod = \tokens -> case tokens of
       (Token RegexMatch (GroupMatch (mm:dd:_)):_) -> do
         m <- parseInt mm


### PR DESCRIPTION
e.g. "New York from 10-6 to 10-22" currently extracts: HH-MM. Instead, it should extract mm-dd i.e. October 10th to October 22nd.