### PR TITLE
Update Dockerfile to build with correct version of Haskell.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM haskell:8
 
+RUN git clone https://github.com/facebookincubator/duckling.git
+
 RUN mkdir /log
 
 WORKDIR /duckling
@@ -7,8 +9,6 @@ WORKDIR /duckling
 RUN apt-get update
 
 RUN apt-get install -qq -y libpcre3 libpcre3-dev build-essential --fix-missing --no-install-recommends
-
-COPY . .
 
 RUN stack setup
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
 FROM haskell:8
 
-RUN git clone https://github.com/facebookincubator/duckling.git
-
 RUN mkdir /log
 
 WORKDIR /duckling
 
 RUN apt-get update
 
-RUN apt-get install libpcre3 libpcre3-dev
+RUN apt-get install -qq -y libpcre3 libpcre3-dev build-essential --fix-missing --no-install-recommends
+
+COPY . .
+
+RUN stack setup
 
 RUN stack build
 


### PR DESCRIPTION
With the current Dockerfile, I get errors when trying to build:

```
Downloading lts-8.8 build plan ...
Downloaded lts-8.8 build plan.
Updating package index Hackage (mirrored at https://s3.amazonaws.com/hackage.fpcomplete.com/) ...
Selected mirror https://s3.amazonaws.com/hackage.fpcomplete.com/
Downloading root
Selected mirror https://s3.amazonaws.com/hackage.fpcomplete.com/
Downloading timestamp
Downloading snapshot
Downloading mirrors
Cannot update index (no local copy)
Downloading index
Updated package list downloaded
Populating index cache ...
Populated index cache.
Compiler version mismatched, found ghc-8.2.1 (x86_64), but expected minor version match with ghc-8.0.2 (x86_64) (based on resolver setting in /duckling/stack.yaml).
To install the correct GHC into /root/.stack/programs/x86_64-linux/, try running "stack setup" or use the "--install-ghc" flag.
The command '/bin/sh -c stack build' returned a non-zero code: 1
```

With these fixes, I run `stack setup` inside the docker image in case it was not setup previously on the host machine.